### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ npm install chrome-launcher
   startingUrl: string;
 
   // (optional) Logging level: verbose, info, error, silent
-  // Default: 'info'
+  // Default: 'silent'
   logLevel: string;
 
   // (optional) Enable extension loading


### PR DESCRIPTION
The `launch()` `logLevel` default was wrong.
See https://github.com/GoogleChrome/chrome-launcher/blob/master/src/chrome-launcher.ts#L116.